### PR TITLE
MINOR: Fix TinyMCE top button row

### DIFF
--- a/app/_config.php
+++ b/app/_config.php
@@ -9,8 +9,8 @@ i18n::set_locale('en_GB');
 // TinyMCE Config
 $config = TinyMCEConfig::get('cms');
 $config->enablePlugins(['anchor']);
-$config->setButtonsForLine(1, 'formatselect | bullist numlist | bold italic subscript superscript
-    | sslink unlink anchor ssmedia');
+$config->setButtonsForLine(1, 'formatselect styleselect | bullist numlist | bold italic subscript superscript |
+    sslink unlink anchor ssmedia');
 $config->setButtonsForLine(2, 'table | pastetext undo redo | code');
 $config->setOptions([
     'block_formats' => 'Paragraph=p;Heading 2=h2;Heading 3=h3'


### PR DESCRIPTION
Looks like the way the button string was split over two lines was causing the superscript button to not be displayed