### PR TITLE
Add support for logging via Sentry

### DIFF
--- a/app/_config/logging.yml
+++ b/app/_config/logging.yml
@@ -5,3 +5,26 @@ SilverStripe\Core\Injector\Injector:
   Psr\Log\LoggerInterface:
     calls:
       ErrorLogHandler: [ pushHandler, [ '%$Monolog\Handler\ErrorLogHandler' ] ]
+---
+Name: app-logging-sentry
+Only:
+  envvarset: 'SENTRY_DSN'
+---
+SilverStripe\Core\Injector\Injector:
+  Psr\Log\LoggerInterface:
+    calls:
+      SentryHandler: [ pushHandler, [ '%$App\Logging\SentryHandler' ] ]
+  App\Logging\SentryHandler:
+    class: 'Monolog\Handler\RavenHandler'
+    constructor:
+      - '%$App\Logging\RavenClient'
+    calls:
+      setFormatter: [ setFormatter, [ '%$App\Logging\SentryLineFormatter' ] ]
+  App\Logging\RavenClient:
+    class: 'Raven_Client'
+    constructor:
+      - '`SENTRY_DSN`'
+  App\Logging\SentryLineFormatter:
+    class: 'Monolog\Formatter\LineFormatter'
+    constructor:
+      - "%message% %context% %extra%\n"

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
 		"heyday/silverstripe-responsive-images": "^2",
 		"kinglozzer/bfgoogleanalytics": "^2",
 		"kinglozzer/metatitle": "^2",
+		"sentry/sentry": "^1",
 		"silverstripe/assets": "^1",
 		"silverstripe/config": "^1",
 		"silverstripe/cms": "^4",

--- a/deploy/recipe/silverstripe.php
+++ b/deploy/recipe/silverstripe.php
@@ -17,6 +17,7 @@ task('silverstripe:create_dotenv', function () {
     $dbUser = ask('Please enter the database username');
     $dbPass = str_replace("'", "\\'", askHiddenResponse('Please enter the database password'));
     $dbName = ask('Please enter the database name', get('application'));
+    $sentryDSN = ask('Please enter the Sentry DSN (if applicable)');
     $dbPrefix = Context::get()->getHost()->getConfig()->get('stage') === 'stage' ? '_stage_' : '';
     $type = Context::get()->getHost()->getConfig()->get('stage') === 'stage' ? 'test' : 'live';
 
@@ -29,6 +30,10 @@ SS_DATABASE_NAME='{$dbName}'
 SS_DATABASE_PREFIX='{$dbPrefix}'
 SS_ENVIRONMENT_TYPE='{$type}'
 ENV;
+
+    if ($sentryDSN) {
+        $contents .= "\nSENTRY_DSN='{$sentryDSN}'";
+    }
 
     $command = <<<BASH
 cat >{$envPath} <<EOL

--- a/util/Bigfork/Installer/Install.php
+++ b/util/Bigfork/Installer/Install.php
@@ -42,6 +42,7 @@ class Install
         $config = [
             'sql-host' => $io->ask('Please specify the database host: '),
             'sql-name' => $io->ask('Please specify the database name: '),
+            'sentry-dsn' => $io->ask('Please enter the Sentry DSN (if applicable): '),
         ];
 
         self::applyConfiguration($config);
@@ -69,6 +70,10 @@ class Install
                 [$config['sql-host'], $config['sql-name']],
                 $env
             );
+
+            if (isset($config['sentry-dsn']) && $config['sentry-dsn']) {
+                $env .= "\nSENTRY_DSN='{$config['sentry-dsn']}'\n";
+            }
 
             file_put_contents($envPath, $env);
         }


### PR DESCRIPTION
@feejin the “DSN” as it’s known will be stored in the `.env` file, it’ll prompt for it when first installing the recipe and when deploying to a new env. Optional both times.

It’s a URL like https://fafw6c5564ca4bc654cb52e876e3fadc@sentry.io/1234567