### PR TITLE
Use imagick driver by default

### DIFF
--- a/app/_config/config.yml
+++ b/app/_config/config.yml
@@ -14,6 +14,10 @@ SilverStripe\Admin\LeftAndMain:
   help_link: 'http://silverstripe.bigfork.co.uk/v3/'
 SilverStripe\Control\Email\Email:
   admin_email: ''
+SilverStripe\Core\Injector\Injector:
+  Intervention\Image\ImageManager:
+    constructor:
+      - { driver: imagick }
 SilverStripe\SiteConfig\SiteConfig:
   extensions:
     - App\Extensions\SiteConfigExtension


### PR DESCRIPTION
Think this is okay @feejin? The only time it wouldn’t be available is if a client is providing hosting