### PR TITLE
Switch namespaced and un-namespaced Page around in hierarchy

### DIFF
--- a/app/src/Control/PageController.php
+++ b/app/src/Control/PageController.php
@@ -2,10 +2,10 @@
 
 namespace App\Control;
 
-use SilverStripe\CMS\Controllers\ContentController;
+use PageController as SilverStripePageController;
 use SilverStripe\View\Requirements;
 
-class PageController extends ContentController
+class PageController extends SilverStripePageController
 {
     protected function init()
     {

--- a/app/src/Model/Page.php
+++ b/app/src/Model/Page.php
@@ -3,15 +3,15 @@
 namespace App\Model;
 
 use App\Control\PageController;
+use Page as SilverStripePage;
 use SilverStripe\CMS\Controllers\RootURLController;
-use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Permission;
 
-class Page extends SiteTree
+class Page extends SilverStripePage
 {
     private static $table_name = 'Page';
 

--- a/app/src/bootstrap.php
+++ b/app/src/bootstrap.php
@@ -6,6 +6,15 @@ use SilverStripe\CMS\Model\SiteTree;
 class Page extends SiteTree
 {
     private static $table_name = 'SilverStripe_Page';
+
+    public function canCreate($member = null, $context = [])
+    {
+        if (static::class === \App\Model\Page::class) {
+            return false;
+        }
+
+        return parent::canCreate($member, $context);
+    }
 }
 
 class PageController extends ContentController

--- a/app/src/bootstrap.php
+++ b/app/src/bootstrap.php
@@ -1,15 +1,13 @@
 <?php
 
-use App\Control\PageController as NamespacedPageController;
-use App\Model\Page as NamespacedPage;
+use SilverStripe\CMS\Controllers\ContentController;
+use SilverStripe\CMS\Model\SiteTree;
 
-class Page extends NamespacedPage
+class Page extends SiteTree
 {
-    private static $hide_ancestor = NamespacedPage::class;
-
     private static $table_name = 'SilverStripe_Page';
 }
 
-class PageController extends NamespacedPageController
+class PageController extends ContentController
 {
 }


### PR DESCRIPTION
I don’t think there’s any way to fix the broken history viewer without this... it looks for `\Page` instances and currently that class sits on its own outside of our `App\Model` hierarchy. Even if I hack around in core to make it look for `\SiteTree` then there are still issues when a user creates a `\Page` before changing it to something else.

Storing the code here for now as it needs properly testing on a project first before merging.