### PR TITLE
Update .htaccess from latest h5bp

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,19 +1,21 @@
-# ##############################################################################
-# # SECURITY                                                                   #
-# ##############################################################################
+# ######################################################################
+# # SECURITY                                                           #
+# ######################################################################
 
-# ------------------------------------------------------------------------------
-# | Disable indexes                                                            |
-# ------------------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# | File access                                                        |
+# ----------------------------------------------------------------------
 
-Options -Indexes
+# Block access to directories without a default document.
 
-# ------------------------------------------------------------------------------
-# | File access                                                                |
-# ------------------------------------------------------------------------------
+<IfModule mod_autoindex.c>
+    Options -Indexes
+</IfModule>
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# Hidden files/folders (.git, .gitignore, .svn etc)
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Block access to all hidden files and directories except for the
+# visible content from within the `/.well-known/` hidden directory.
 
 <IfModule mod_rewrite.c>
     RewriteEngine On
@@ -23,98 +25,141 @@ Options -Indexes
     RewriteRule "(^|/)\." - [F]
 </IfModule>
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# Sensitive filetypes
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-<FilesMatch "(^#.*#|\.(bak|codekit3|config|dist|fla|inc|ini|log|psd|sh|sql|ss|sublime-.*|sw[op]|ya?ml)|~)$">
-    # Apache < 2.3
-    <IfModule !mod_authz_core.c>
-        Order allow,deny
-        Deny from all
-        Satisfy All
-    </IfModule>
+# Block access to files that can expose sensitive information.
+#
 
-    # Apache ≥ 2.3
-    <IfModule mod_authz_core.c>
+<IfModule mod_authz_core.c>
+    <FilesMatch "(^#.*#|\.(bak|conf|config|dist|fla|in[ci]|log|orig|psd|sh|sql|sw[op]|ya?ml)|~)$">
         Require all denied
-    </IfModule>
-</FilesMatch>
+    </FilesMatch>
+</IfModule>
 
-# ##############################################################################
-# # URL REWRITES                                                               #
-# ##############################################################################
+# ----------------------------------------------------------------------
+# | Content Type Options                                               |
+# ----------------------------------------------------------------------
 
-# ------------------------------------------------------------------------------
-# | Rewrite rules                                                              |
-# ------------------------------------------------------------------------------
+# Prevent some browsers from MIME-sniffing the response.
+
+<IfModule mod_headers.c>
+    Header always set X-Content-Type-Options "nosniff"
+</IfModule>
+
+# ----------------------------------------------------------------------
+# | Server software information                                        |
+# ----------------------------------------------------------------------
+
+# Turn off Apache server signatures
+
+ServerSignature Off
+
+# ######################################################################
+# # REWRITES                                                           #
+# ######################################################################
+
+# ----------------------------------------------------------------------
+# | Rewrite engine                                                     |
+# ----------------------------------------------------------------------
 
 <IfModule mod_rewrite.c>
-    <IfModule mod_env.c>
-        SetEnv HTTP_MOD_REWRITE On
-    </IfModule>
-
     RewriteEngine On
-
-    # Force www.actualdomain.com with 301 redirects
-    # RewriteCond %{HTTP_HOST} !^.*\.(test|dev|devdomain\.co\.uk)$ [NC]
-    # RewriteCond %{HTTP_HOST} !^www\.actualdomain\.com$ [NC]
-    # RewriteRule ^(.*)$ http://www.actualdomain.com/$1 [R=301,L]
-
     RewriteBase '/'
+</IfModule>
 
-    # SilverStripe rewrites
-    RewriteCond %{REQUEST_URI} ^(.*)$
+# ----------------------------------------------------------------------
+# | Suppress the `www.` at the beginning of URLs                       |
+# ----------------------------------------------------------------------
+
+# Rewrite www.example.com → example.com
+
+<IfModule mod_rewrite.c>
+#    RewriteCond %{HTTPS} =on
+#    RewriteRule ^ - [E=PROTO:https]
+#    RewriteCond %{HTTPS} !=on
+#    RewriteRule ^ - [E=PROTO:http]
+#
+#    RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+#    RewriteRule ^ %{ENV:PROTO}://%1%{REQUEST_URI} [R=301,L]
+</IfModule>
+
+# -----------------------------------------------------------------------
+# | Force the `www.` at the beginning of URLs                           |
+# -----------------------------------------------------------------------
+
+# Rewrite example.com → www.example.com
+
+<IfModule mod_rewrite.c>
+#     RewriteCond %{HTTPS} =on
+#     RewriteRule ^ - [E=PROTO:https]
+#     RewriteCond %{HTTPS} !=on
+#     RewriteRule ^ - [E=PROTO:http]
+#
+#     RewriteCond %{HTTP_HOST} !^www\. [NC]
+#     RewriteCond %{SERVER_ADDR} !=127.0.0.1
+#     RewriteCond %{SERVER_ADDR} !=::1
+#     RewriteRule ^ %{ENV:PROTO}://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+</IfModule>
+
+# ----------------------------------------------------------------------
+# | Rewrite rules                                                      |
+# ----------------------------------------------------------------------
+
+# Enable Silverstripe-specific rewrites
+
+<IfModule mod_rewrite.c>
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule .* index.php
 </IfModule>
 
-# ------------------------------------------------------------------------------
-# | Error documents                                                            |
-# ------------------------------------------------------------------------------
+# ######################################################################
+# # ERRORS                                                             #
+# ######################################################################
+
+# ----------------------------------------------------------------------
+# | Custom error messages/pages                                        |
+# ----------------------------------------------------------------------
+
+# Customize what Apache returns to the client in case of an error.
+#
+# https://httpd.apache.org/docs/current/mod/core.html#errordocument
 
 ErrorDocument 404 /assets/error-404.html
 ErrorDocument 500 /assets/error-500.html
 
-# ##############################################################################
-# # INTERNET EXPLORER                                                          #
-# ##############################################################################
 
-# ------------------------------------------------------------------------------
-# | Force IE to use latest version                                             |
-# ------------------------------------------------------------------------------
+# ######################################################################
+# # CROSS-ORIGIN                                                       #
+# ######################################################################
 
-<IfModule mod_headers.c>
-    Header set X-UA-Compatible "IE=Edge,chrome=1"
-    # mod_headers can't match by content-type, but we don't want to send this header on *everything*
-    <FilesMatch "\.(js|css|gif|png|jpe?g|pdf|xml|oga|ogg|m4a|ogv|mp4|m4v|webm|svg|svgz|eot|ttf|otf|woff|ico|webp|appcache|manifest|htc|crx|xpi|safariextz|vcf)$" >
-        Header unset X-UA-Compatible
-    </FilesMatch>
-</IfModule>
+# ----------------------------------------------------------------------
+# | Cross-origin web fonts                                             |
+# ----------------------------------------------------------------------
 
-# ##############################################################################
-# # COMPRESSION, MIME TYPES, ENCODING                                          #
-# ##############################################################################
-
-# ------------------------------------------------------------------------------
-# | Web fonts access                                                           |
-# ------------------------------------------------------------------------------
-
-# Allow access from all domains for web fonts
+# Allow cross-origin access to web fonts.
+#
+# https://developers.google.com/fonts/docs/troubleshooting
 
 <IfModule mod_headers.c>
-    <FilesMatch "\.(eot|otf|ttc|ttf|woff)$">
+    <FilesMatch "\.(eot|otf|tt[cf]|woff2?)$">
         Header set Access-Control-Allow-Origin "*"
     </FilesMatch>
 </IfModule>
 
-# ------------------------------------------------------------------------------
-# | Gzip compression                                                           |
-# ------------------------------------------------------------------------------
+# ######################################################################
+# # WEB PERFORMANCE                                                    #
+# ######################################################################
+
+# ----------------------------------------------------------------------
+# | Compression                                                        |
+# ----------------------------------------------------------------------
 
 <IfModule mod_deflate.c>
+    # Force compression for mangled `Accept-Encoding` request headers
+    #
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
+    # https://calendar.perfplanet.com/2010/pushing-beyond-gzipping/
 
-    # Force compression for mangled headers.
-    # http://developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping
     <IfModule mod_setenvif.c>
         <IfModule mod_headers.c>
             SetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\s*,?\s*)+|[X~-]{4,13}$ HAVE_Accept-Encoding
@@ -122,172 +167,248 @@ ErrorDocument 500 /assets/error-500.html
         </IfModule>
     </IfModule>
 
-    # HTML, TXT, CSS, JavaScript, JSON, XML, HTC:
-	<IfModule mod_filter.c>
-        AddOutputFilterByType DEFLATE application/atom+xml \
-                                      application/javascript \
-                                      application/json \
-                                      application/ld+json \
-                                      application/manifest+json \
-                                      application/rss+xml \
-                                      application/vnd.ms-fontobject \
-                                      application/x-font-ttf \
-                                      application/x-web-app-manifest+json \
-                                      application/xhtml+xml \
-                                      application/xml \
-                                      font/opentype \
-                                      image/svg+xml \
-                                      image/x-icon \
-                                      text/css \
-                                      text/html \
-                                      text/plain \
-                                      text/vtt \
-                                      text/x-component \
-                                      text/xml
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    # Compress all output labeled with one of the following media types.
+    #
+    # https://httpd.apache.org/docs/current/mod/mod_filter.html#addoutputfilterbytype
+
+    <IfModule mod_filter.c>
+        AddOutputFilterByType DEFLATE "application/atom+xml" \
+                                      "application/javascript" \
+                                      "application/json" \
+                                      "application/ld+json" \
+                                      "application/manifest+json" \
+                                      "application/rdf+xml" \
+                                      "application/rss+xml" \
+                                      "application/schema+json" \
+                                      "application/geo+json" \
+                                      "application/vnd.ms-fontobject" \
+                                      "application/wasm" \
+                                      "application/x-font-ttf" \
+                                      "application/x-javascript" \
+                                      "application/x-web-app-manifest+json" \
+                                      "application/xhtml+xml" \
+                                      "application/xml" \
+                                      "font/eot" \
+                                      "font/opentype" \
+                                      "font/otf" \
+                                      "font/ttf" \
+                                      "image/bmp" \
+                                      "image/svg+xml" \
+                                      "image/vnd.microsoft.icon" \
+                                      "image/x-icon" \
+                                      "text/cache-manifest" \
+                                      "text/calendar" \
+                                      "text/css" \
+                                      "text/html" \
+                                      "text/javascript" \
+                                      "text/plain" \
+                                      "text/markdown" \
+                                      "text/vcard" \
+                                      "text/vnd.rim.location.xloc" \
+                                      "text/vtt" \
+                                      "text/x-component" \
+                                      "text/x-cross-domain-policy" \
+                                      "text/xml"
     </IfModule>
 
-    <IfModule !mod_filter.c>
-        # Legacy versions of Apache
-        AddOutputFilterByType DEFLATE text/html text/plain text/css application/json
-        AddOutputFilterByType DEFLATE application/javascript
-        AddOutputFilterByType DEFLATE text/xml application/xml text/x-component
-        AddOutputFilterByType DEFLATE application/xhtml+xml application/rss+xml application/atom+xml
-        AddOutputFilterByType DEFLATE image/x-icon image/svg+xml application/vnd.ms-fontobject application/x-font-ttf font/opentype
-    </IfModule>
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+    # Map the following filename extensions to the specified encoding type in
+    # order to make Apache serve the file types with the appropriate
+    # `Content-Encoding` response header (do note that this will NOT make
+    # Apache compress them!).
+    #
+    # If these files types would be served without an appropriate
+    # `Content-Encoding` response header, client applications (e.g.: browsers)
+    # wouldn't know that they first need to uncompress the response, and thus,
+    # wouldn't be able to understand the content.
+    #
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
+    # https://httpd.apache.org/docs/current/mod/mod_mime.html#addencoding
+
+    <IfModule mod_mime.c>
+        AddEncoding gzip              svgz
+    </IfModule>
 </IfModule>
 
-# ------------------------------------------------------------------------------
-# | Proper MIME types for all files                                            |
-# ------------------------------------------------------------------------------
+
+# ######################################################################
+# # MEDIA TYPES AND CHARACTER ENCODINGS                                #
+# ######################################################################
+
+# ----------------------------------------------------------------------
+# | Media types                                                        |
+# ----------------------------------------------------------------------
+
+# Serve resources with the proper media types (f.k.a. MIME types).
+#
+# https://www.iana.org/assignments/media-types/media-types.xhtml
+# https://httpd.apache.org/docs/current/mod/mod_mime.html#addtype
 
 <IfModule mod_mime.c>
+    # Data interchange
+    AddType application/atom+xml                        atom
+    AddType application/json                            json map topojson
+    AddType application/ld+json                         jsonld
+    AddType application/rss+xml                         rss
+    AddType application/geo+json                        geojson
+    AddType application/rdf+xml                         rdf
+    AddType application/xml                             xml
 
-# Audio
-    AddType audio/mp4                                   m4a f4a f4b
-    AddType audio/ogg                                   oga ogg
+    # JavaScript
+    # Servers should use text/javascript for JavaScript resources.
+    # https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages
+    AddType text/javascript                             js mjs
 
-# JavaScript
-    # Normalize to standard type (it's sniffed in IE anyways):
-    # http://tools.ietf.org/html/rfc4329#section-7.2
-    AddType application/javascript                      js
-    AddType application/json                            json
 
-# Video
+    # Manifest files
+    AddType application/manifest+json                   webmanifest
+    AddType application/x-web-app-manifest+json         webapp
+    AddType text/cache-manifest                         appcache
+
+    # Media files
+    AddType audio/mp4                                   f4a f4b m4a
+    AddType audio/ogg                                   oga ogg opus
+    AddType image/avif                                  avif avifs
+    AddType image/bmp                                   bmp
+    AddType image/jxl                                   jxl
+    AddType image/svg+xml                               svg svgz
+    AddType image/webp                                  webp
     AddType video/mp4                                   f4v f4p m4v mp4
     AddType video/ogg                                   ogv
     AddType video/webm                                  webm
     AddType video/x-flv                                 flv
 
-# Web fonts
-    AddType application/font-woff                       woff
+    # Serving `.ico` image files with a different media type prevents
+    # Internet Explorer from displaying them as images:
+    # https://github.com/h5bp/html5-boilerplate/commit/37b5fec090d00f38de64b591bcddcb205aadf8ee
+    AddType image/x-icon                                cur ico
+
+    # WebAssembly
+    AddType application/wasm                            wasm
+
+  # Web fonts
+    AddType font/woff                                   woff
+    AddType font/woff2                                  woff2
     AddType application/vnd.ms-fontobject               eot
+    AddType font/ttf                                    ttf
+    AddType font/collection                             ttc
+    AddType font/otf                                    otf
 
-    # Browsers usually ignore the font MIME types and sniff the content,
-    # however, Chrome shows a warning if other MIME types are used for the
-    # following fonts.
-    AddType application/x-font-ttf                      ttc ttf
-    AddType font/opentype                               otf
-
-    # Make SVGZ fonts work on iPad:
-    # https://twitter.com/FontSquirrel/status/14855840545
-    AddType     image/svg+xml                           svgz
-    AddEncoding gzip                                    svgz
-
-# Other
+    # Other
     AddType application/octet-stream                    safariextz
+    AddType application/x-bb-appworld                   bbaw
     AddType application/x-chrome-extension              crx
     AddType application/x-opera-extension               oex
-    AddType application/x-web-app-manifest+json         webapp
     AddType application/x-xpinstall                     xpi
-    AddType application/xml                             atom rdf rss xml
-    AddType image/webp                                  webp
-    AddType image/x-icon                                cur
-    AddType text/cache-manifest                         appcache manifest
+    AddType text/calendar                               ics
+    AddType text/markdown                               markdown md
+    AddType text/vcard                                  vcard vcf
+    AddType text/vnd.rim.location.xloc                  xloc
     AddType text/vtt                                    vtt
     AddType text/x-component                            htc
-    AddType text/x-vcard                                vcf
-
 </IfModule>
 
-# ------------------------------------------------------------------------------
-# | UTF-8 encoding                                                             |
-# ------------------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# | Character encodings                                                |
+# ----------------------------------------------------------------------
 
-# Use UTF-8 encoding for anything served as `text/html` or `text/plain`.
+# Serve all resources labeled as `text/html` or `text/plain` with the media type
+# `charset` parameter set to `UTF-8`.
+#
+# https://httpd.apache.org/docs/current/mod/core.html#adddefaultcharset
+
 AddDefaultCharset utf-8
 
-# Force UTF-8 for certain file formats.
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Serve the following file types with the media type `charset` parameter set to
+# `UTF-8`.
+#
+# https://httpd.apache.org/docs/current/mod/mod_mime.html#addcharset
+
 <IfModule mod_mime.c>
-    AddCharset utf-8 .atom .css .js .json .rss .vtt .webapp .xml
+    AddCharset utf-8 .appcache \
+                     .bbaw \
+                     .css \
+                     .htc \
+                     .ics \
+                     .js \
+                     .json \
+                     .manifest \
+                     .map \
+                     .markdown \
+                     .md \
+                     .mjs \
+                     .topojson \
+                     .vtt \
+                     .vcard \
+                     .vcf \
+                     .webmanifest \
+                     .xloc
 </IfModule>
 
-# ##############################################################################
-# # CACHE CONTROL                                                              #
-# ##############################################################################
+# ----------------------------------------------------------------------
+# | ETags                                                              |
+# ----------------------------------------------------------------------
 
-# ------------------------------------------------------------------------------
-# | ETag removal                                                               |
-# ------------------------------------------------------------------------------
+# Remove `ETags` as resources are sent with far-future expires headers.
 
-# `FileETag None` is not enough for every server.
+# `FileETag None` doesn't work in all cases.
 <IfModule mod_headers.c>
     Header unset ETag
 </IfModule>
 
 FileETag None
 
-# ------------------------------------------------------------------------------
-# | Expires headers (for better cache control)                                 |
-# ------------------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# | Cache expiration                                                   |
+# ----------------------------------------------------------------------
+
+# Serve resources with a far-future expiration date.
+#
+# (!) If you don't control versioning with filename-based cache busting, you
+#     should consider lowering the cache times to something like one week.
+#
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expires
+# https://httpd.apache.org/docs/current/mod/mod_expires.html
 
 <IfModule mod_expires.c>
     ExpiresActive on
 
-# Perhaps better to whitelist expires rules? Perhaps.
-    ExpiresDefault                                      "access plus 1 month"
+    # Default: Fallback
+    ExpiresDefault                                      "access plus 1 year"
 
-# Manifest files
-    ExpiresByType text/cache-manifest                   "access plus 0 seconds"
-    ExpiresByType application/x-web-app-manifest+json   "access plus 0 seconds"
-
-# HTML
-    ExpiresByType text/html                             "access plus 0 seconds"
-
-# Data
-    ExpiresByType text/xml                              "access plus 0 seconds"
-    ExpiresByType application/xml                       "access plus 0 seconds"
-    ExpiresByType application/json                      "access plus 0 seconds"
-
-# Feed
-    ExpiresByType application/rss+xml                   "access plus 1 hour"
-    ExpiresByType application/atom+xml                  "access plus 1 hour"
-
-# Favicon (cannot be renamed)
+    # Specific: Assets
+    ExpiresByType image/vnd.microsoft.icon              "access plus 1 week"
     ExpiresByType image/x-icon                          "access plus 1 week"
 
-# Media: images, video, audio
-    ExpiresByType image/gif                             "access plus 1 year"
-    ExpiresByType image/png                             "access plus 1 year"
-    ExpiresByType image/jpg                             "access plus 1 year"
-    ExpiresByType image/jpeg                            "access plus 1 year"
-    ExpiresByType video/ogg                             "access plus 1 year"
-    ExpiresByType audio/ogg                             "access plus 1 year"
-    ExpiresByType video/mp4                             "access plus 1 year"
-    ExpiresByType video/webm                            "access plus 1 year"
-    ExpiresByType image/svg+xml                         "access plus 1 year"
+    # Specific: Manifests
+    ExpiresByType application/manifest+json             "access plus 1 week"
+    ExpiresByType application/x-web-app-manifest+json   "access"
+    ExpiresByType text/cache-manifest                   "access"
 
-# HTC files  (css3pie)
-    ExpiresByType text/x-component                      "access plus 1 month"
+    # Specific: Data interchange
+    ExpiresByType application/atom+xml                  "access plus 1 hour"
+    ExpiresByType application/rdf+xml                   "access plus 1 hour"
+    ExpiresByType application/rss+xml                   "access plus 1 hour"
 
-# Webfonts
-    ExpiresByType application/x-font-ttf                "access plus 1 month"
-    ExpiresByType font/opentype                         "access plus 1 month"
-    ExpiresByType application/x-font-woff               "access plus 1 month"
-    ExpiresByType application/vnd.ms-fontobject         "access plus 1 month"
+    # Specific: Documents
+    ExpiresByType text/html                             "access"
+    ExpiresByType text/markdown                         "access"
+    ExpiresByType text/calendar                         "access"
 
-# CSS and JavaScript
-    ExpiresByType text/css                              "access plus 1 year"
-    ExpiresByType application/javascript                "access plus 1 year"
+    # Specific: Other
+    ExpiresByType text/x-cross-domain-policy            "access plus 1 week"
 
+    # Generic: Data
+    ExpiresByType application/json                      "access"
+    ExpiresByType application/ld+json                   "access"
+    ExpiresByType application/schema+json               "access"
+    ExpiresByType application/geo+json                  "access"
+    ExpiresByType application/xml                       "access"
+    ExpiresByType text/xml                              "access"
 </IfModule>


### PR DESCRIPTION
A lot of this is just re-ordering and/or simplifying things. The main _actual_ changes are:

- Remove old IE crap
- Remove old Apache syntaxes/rules
- Increase default cache length to 1 year
- Add `X-Content-Type-Options: "nosniff"` header